### PR TITLE
Connect to sections collection and visualise items

### DIFF
--- a/.firebase/firestore.rules
+++ b/.firebase/firestore.rules
@@ -13,5 +13,10 @@ service cloud.firestore {
     match /new/{userId} {
       allow read, write: if request.auth.uid == userId;
     }
+
+    match /sections/{sectionId} {
+      allow read: if request.auth.uid != null;
+      allow write: if false;
+    }
   }
 }

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  errors:
+    todo: error
+    unused_import: error
+  exclude: [build/**]
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false

--- a/lib/actions/sections/store_sections.dart
+++ b/lib/actions/sections/store_sections.dart
@@ -1,0 +1,35 @@
+library store_sections;
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:meta/meta.dart';
+import 'package:the_process/actions/redux_action.dart';
+import 'package:the_process/serializers.dart';
+
+part 'store_sections.g.dart';
+
+abstract class StoreSections extends Object
+    with ReduxAction
+    implements Built<StoreSections, StoreSectionsBuilder> {
+  BuiltList get list;
+
+  StoreSections._();
+
+  factory StoreSections({@required BuiltList list}) = _$StoreSections._;
+
+  factory StoreSections.by([void Function(StoreSectionsBuilder) updates]) =
+      _$StoreSections;
+
+  Object toJson() => serializers.serializeWith(StoreSections.serializer, this);
+
+  static StoreSections fromJson(String jsonString) => serializers
+      .deserializeWith(StoreSections.serializer, json.decode(jsonString));
+
+  static Serializer<StoreSections> get serializer => _$storeSectionsSerializer;
+
+  @override
+  String toString() => 'STORE_SECTIONS';
+}

--- a/lib/actions/shared/connect_database.dart
+++ b/lib/actions/shared/connect_database.dart
@@ -1,0 +1,38 @@
+library connect_database;
+
+import 'dart:convert';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:meta/meta.dart';
+import 'package:the_process/actions/redux_action.dart';
+import 'package:the_process/enums/database/database_section.dart';
+import 'package:the_process/serializers.dart';
+
+part 'connect_database.g.dart';
+
+abstract class ConnectDatabase extends Object
+    with ReduxAction
+    implements Built<ConnectDatabase, ConnectDatabaseBuilder> {
+  DatabaseSection get section;
+
+  ConnectDatabase._();
+
+  factory ConnectDatabase({@required DatabaseSection section}) =
+      _$ConnectDatabase._;
+
+  factory ConnectDatabase.by([void Function(ConnectDatabaseBuilder) updates]) =
+      _$ConnectDatabase;
+
+  Object toJson() =>
+      serializers.serializeWith(ConnectDatabase.serializer, this);
+
+  static ConnectDatabase fromJson(String jsonString) => serializers
+      .deserializeWith(ConnectDatabase.serializer, json.decode(jsonString));
+
+  static Serializer<ConnectDatabase> get serializer =>
+      _$connectDatabaseSerializer;
+
+  @override
+  String toString() => 'CONNECT_DATABASE';
+}

--- a/lib/enums/database/database_section.dart
+++ b/lib/enums/database/database_section.dart
@@ -8,10 +8,12 @@ part 'database_section.g.dart';
 class DatabaseSection extends EnumClass {
   static const DatabaseSection profileData = _$profileData;
   static const DatabaseSection newEntries = _$newEntries;
+  static const DatabaseSection sections = _$sections;
 
   static const Map<DatabaseSection, int> _$indexMap = {
     profileData: 0,
     newEntries: 1,
+    sections: 2,
   };
 
   const DatabaseSection._(String name) : super(name);

--- a/lib/extensions/dart_core_extensions.dart
+++ b/lib/extensions/dart_core_extensions.dart
@@ -1,7 +1,7 @@
 import 'package:the_process/enums/navigation/nav_bar_selection.dart';
 
-extension intExt on int {
-  toNavBarSelection() {
+extension IntExt on int {
+  NavBarSelection toNavBarSelection() {
     switch (this) {
       case 0:
         return NavBarSelection.sections;

--- a/lib/extensions/firestore_extensions.dart
+++ b/lib/extensions/firestore_extensions.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:the_process/enums/auth/authorization_step.dart';
 import 'package:the_process/models/profile/profile_data.dart';
+import 'package:the_process/models/sections/section.dart';
 
 extension ConvertDocumentSnapshot on DocumentSnapshot {
   ProfileData toProfileData() => ProfileData(
@@ -10,6 +11,14 @@ extension ConvertDocumentSnapshot on DocumentSnapshot {
           'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y',
       firstName: data()['firstName'] as String ?? '_',
       lastName: data()['lastName'] as String ?? '_',
-      googleAuth: AuthorizationStep.valueOf(data()['googleAuth']),
-      asanaAuth: AuthorizationStep.valueOf(data()['asanaAuth']));
+      googleAuth: AuthorizationStep.valueOf(data()['googleAuth'] as String),
+      asanaAuth: AuthorizationStep.valueOf(data()['asanaAuth'] as String));
+}
+
+extension ConvertQueryDocumentSnapshot on QueryDocumentSnapshot {
+  Section toSection() => Section(
+      number: data()['number'] as int,
+      name: data()['name'] as String,
+      folderId: data()['folderId'] as String,
+      useCasesDocId: data()['useCasesDocId'] as String);
 }

--- a/lib/extensions/redux_extensions.dart
+++ b/lib/extensions/redux_extensions.dart
@@ -3,6 +3,6 @@ import 'package:the_process/actions/problems/add_problem.dart';
 import 'package:the_process/models/app_state/app_state.dart';
 
 extension StoreExt on Store<AppState> {
-  dispatchProblem(dynamic error, StackTrace trace) => dispatch(
+  dynamic dispatchProblem(dynamic error, StackTrace trace) => dispatch(
       AddProblem(errorString: error.toString(), traceString: trace.toString()));
 }

--- a/lib/middleware/app_middleware.dart
+++ b/lib/middleware/app_middleware.dart
@@ -9,6 +9,7 @@ import 'package:the_process/middleware/profile/disregard_profile_data.dart';
 import 'package:the_process/middleware/profile/get_authorized.dart';
 import 'package:the_process/middleware/profile/observe_profile_data.dart';
 import 'package:the_process/middleware/sections/create_section.dart';
+import 'package:the_process/middleware/shared/connect_database.dart';
 import 'package:the_process/models/app_state/app_state.dart';
 import 'package:the_process/services/auth_service.dart';
 import 'package:the_process/services/database_service.dart';
@@ -43,5 +44,7 @@ List<Middleware<AppState>> createAppMiddleware({
     ObserveProfileDataMiddleware(databaseService),
     // Sections
     CreateSectionMiddleware(databaseService),
+    // Shared
+    ConnectDatabaseMiddleware(databaseService),
   ];
 }

--- a/lib/middleware/profile/get_authorized.dart
+++ b/lib/middleware/profile/get_authorized.dart
@@ -17,10 +17,8 @@ class GetAuthorizedMiddleware extends TypedMiddleware<AppState, GetAuthorized> {
               uid: store.state.authUserData.uid,
               step: AuthorizationStep.gettingAuthorized);
 
+          // can improve security by saving to database and sending in 'state'
           final unguessable = Uuid().v1();
-
-          // TODO: save unguessable to new/uid/authorizing so cloud functions
-          // can match unguessable to firebase UID
 
           await platformService.getAuthorized(
               provider: action.toAccess, state: unguessable);

--- a/lib/middleware/shared/connect_database.dart
+++ b/lib/middleware/shared/connect_database.dart
@@ -1,0 +1,17 @@
+import 'package:redux/redux.dart';
+import 'package:the_process/actions/shared/connect_database.dart';
+import 'package:the_process/enums/database/database_section.dart';
+import 'package:the_process/models/app_state/app_state.dart';
+import 'package:the_process/services/database_service.dart';
+
+class ConnectDatabaseMiddleware
+    extends TypedMiddleware<AppState, ConnectDatabase> {
+  ConnectDatabaseMiddleware(DatabaseService databaseService)
+      : super((store, action, next) async {
+          next(action);
+
+          if (action.section == DatabaseSection.sections) {
+            databaseService.connectSections();
+          }
+        });
+}

--- a/lib/models/sections/section.dart
+++ b/lib/models/sections/section.dart
@@ -1,0 +1,34 @@
+library section;
+
+import 'dart:convert';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:meta/meta.dart';
+import 'package:the_process/serializers.dart';
+
+part 'section.g.dart';
+
+abstract class Section implements Built<Section, SectionBuilder> {
+  int get number;
+  String get name;
+  String get folderId;
+  String get useCasesDocId;
+
+  Section._();
+
+  factory Section(
+      {@required int number,
+      @required String name,
+      @required String folderId,
+      @required String useCasesDocId}) = _$Section._;
+
+  factory Section.by([void Function(SectionBuilder) updates]) = _$Section;
+
+  Object toJson() => serializers.serializeWith(Section.serializer, this);
+
+  static Section fromJson(String jsonString) =>
+      serializers.deserializeWith(Section.serializer, json.decode(jsonString));
+
+  static Serializer<Section> get serializer => _$sectionSerializer;
+}

--- a/lib/models/sections/sections_v_m.dart
+++ b/lib/models/sections/sections_v_m.dart
@@ -2,16 +2,19 @@ library sections_v_m;
 
 import 'dart:convert';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:meta/meta.dart';
 import 'package:the_process/models/sections/new_section_v_m.dart';
+import 'package:the_process/models/sections/section.dart';
 import 'package:the_process/serializers.dart';
 
 part 'sections_v_m.g.dart';
 
 abstract class SectionsVM implements Built<SectionsVM, SectionsVMBuilder> {
   NewSectionVM get newSection;
+  BuiltList<Section> get list;
 
   SectionsVM._();
 

--- a/lib/reducers/app_reducer.dart
+++ b/lib/reducers/app_reducer.dart
@@ -10,6 +10,7 @@ import 'package:the_process/reducers/problems/add_problem.dart';
 import 'package:the_process/reducers/problems/remove_problem.dart';
 import 'package:the_process/reducers/profile/store_profile_data.dart';
 import 'package:the_process/reducers/sections/create_section.dart';
+import 'package:the_process/reducers/sections/store_sections.dart';
 import 'package:the_process/reducers/sections/update_new_section_v_m.dart';
 import 'package:the_process/reducers/settings/update_settings.dart';
 
@@ -34,6 +35,7 @@ final appReducer =
   StoreProfileDataReducer(),
   // Sections
   CreateSectionReducer(),
+  StoreSectionsReducer(),
   UpdateNewSectionVMReducer(),
   // Settings
   UpdateSettingsReducer(),

--- a/lib/reducers/sections/store_sections.dart
+++ b/lib/reducers/sections/store_sections.dart
@@ -1,0 +1,9 @@
+import 'package:redux/redux.dart';
+import 'package:the_process/actions/sections/store_sections.dart';
+import 'package:the_process/models/app_state/app_state.dart';
+
+class StoreSectionsReducer extends TypedReducer<AppState, StoreSections> {
+  StoreSectionsReducer()
+      : super((state, action) =>
+            state.rebuild((b) => b..sections.list.replace(action.list)));
+}

--- a/lib/serializers.dart
+++ b/lib/serializers.dart
@@ -38,6 +38,7 @@ import 'package:the_process/models/navigation/page_data/profile_page_data.dart';
 import 'package:the_process/models/problems/problem.dart';
 import 'package:the_process/models/profile/profile_data.dart';
 import 'package:the_process/models/sections/new_section_v_m.dart';
+import 'package:the_process/models/sections/section.dart';
 import 'package:the_process/models/sections/sections_v_m.dart';
 import 'package:the_process/models/settings/settings.dart';
 import 'package:the_process/models/settings/theme_colors.dart';
@@ -77,6 +78,7 @@ part 'serializers.g.dart';
   PushPage,
   RemoveCurrentPage,
   RemoveProblem,
+  Section,
   SectionsVM,
   Settings,
   SignInWithApple,

--- a/lib/services/platform_service.dart
+++ b/lib/services/platform_service.dart
@@ -36,7 +36,7 @@ class PlatformService {
 
   Future<void> getAuthorized(
       {@required Provider provider, @required String state}) async {
-    var url;
+    String url;
     if (provider == Provider.google) {
       url =
           'https://us-central1-the-process-tool.cloudfunctions.net/getGoogleAuthorization?state=$state';

--- a/lib/widgets/home/home_page.dart
+++ b/lib/widgets/home/home_page.dart
@@ -26,10 +26,12 @@ class _HomePageState extends State<HomePage> {
         children: <Widget>[
           NavRail(),
           VerticalDivider(thickness: 1, width: 1),
-          StoreConnector<AppState, NavBarSelection>(
-            distinct: true,
-            converter: (store) => store.state.navSelection,
-            builder: (context, selection) => widgetFrom[selection],
+          Expanded(
+            child: StoreConnector<AppState, NavBarSelection>(
+              distinct: true,
+              converter: (store) => store.state.navSelection,
+              builder: (context, selection) => widgetFrom[selection],
+            ),
           )
         ],
       ),

--- a/lib/widgets/sections/sections_page.dart
+++ b/lib/widgets/sections/sections_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:the_process/actions/sections/create_section.dart';
 import 'package:the_process/actions/sections/update_new_section_v_m.dart';
+import 'package:the_process/actions/shared/connect_database.dart';
+import 'package:the_process/enums/database/database_section.dart';
 import 'package:the_process/extensions/flutter_extensions.dart';
 import 'package:the_process/models/app_state/app_state.dart';
 import 'package:the_process/models/sections/sections_v_m.dart';
@@ -12,51 +14,76 @@ class SectionsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StoreConnector<AppState, SectionsVM>(
+      onInit: (store) =>
+          store.dispatch(ConnectDatabase(section: DatabaseSection.sections)),
       distinct: true,
       converter: (store) => store.state.sections,
       builder: (context, vm) {
         if (vm.newSection.creating) {
           return WaitingIndicator('Creating...');
         }
-        return Row(
-          mainAxisSize: MainAxisSize.min,
+        return Column(
           children: [
-            SizedBox(
-              width: 50,
-              child: TextField(
-                  keyboardType: TextInputType.number,
-                  controller: TextEditingController(
-                      text: vm.newSection.number.toString()),
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                  ),
-                  onChanged: (value) {
-                    final intValue = int.tryParse(value);
-                    if (intValue != null) {
-                      context.dispatch(UpdateNewSectionVM(number: intValue));
-                    }
-                  }),
-            ),
-            SizedBox(
-              width: 15,
-            ),
-            SizedBox(
-              width: 200,
-              child: TextFormField(
-                autofocus: true,
-                decoration: InputDecoration(
-                    border: InputBorder.none, hintText: 'Enter a name...'),
-                onChanged: (value) =>
-                    context.dispatch(UpdateNewSectionVM(name: value)),
+            ListView.builder(
+              shrinkWrap: true,
+              itemCount: vm.list.length,
+              itemBuilder: (context, index) => Card(
+                child: ListTile(title: Text(vm.list[index].name)),
               ),
             ),
-            MaterialButton(
-              child: Text('GO'),
-              onPressed: () => context.dispatch(CreateSection()),
-            )
+            NewSectionItem('${vm.newSection.number}'),
           ],
         );
       },
+    );
+  }
+}
+
+class NewSectionItem extends StatelessWidget {
+  final String startingNumber;
+  const NewSectionItem(
+    this.startingNumber, {
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 50,
+          child: TextField(
+              keyboardType: TextInputType.number,
+              controller: TextEditingController(text: startingNumber),
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+              ),
+              onChanged: (value) {
+                final intValue = int.tryParse(value);
+                if (intValue != null) {
+                  context.dispatch(UpdateNewSectionVM(number: intValue));
+                }
+              }),
+        ),
+        SizedBox(
+          width: 15,
+        ),
+        SizedBox(
+          width: 200,
+          child: TextFormField(
+            autofocus: true,
+            decoration: InputDecoration(
+                border: InputBorder.none, hintText: 'Enter a name...'),
+            onChanged: (value) =>
+                context.dispatch(UpdateNewSectionVM(name: value)),
+          ),
+        ),
+        MaterialButton(
+          child: Text('GO'),
+          onPressed: () => context.dispatch(CreateSection()),
+        )
+      ],
     );
   }
 }


### PR DESCRIPTION
- added analysis_options.yaml with strong mode and fixed errors
- added a firestore rule to allow access to 'sections' collection
- added actions, middleware & reducers for connecting to sections
- added a database service function to use
firestore to get a stream of snapshots of the sections collection
- added a Section model and an extansion on QueryDocumentSnapshot to
convert docs to Section objects
- added a list of Section to SectionsVM and a ListView to
SectionsPage to visualise the list